### PR TITLE
Adding main property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/js-data/js-data-angular.git"
   },
+  "main": "dist/js-data-angular.js",
   "author": {
     "name": "Jason Dobry",
     "url": "http://www.pseudobry.com",


### PR DESCRIPTION
Allows me to simply `require('js-data-angular')` rather than having to `require('js-data-angular/dist/js-data-angular')`. Also, I recommend exporting the name of the angular module. See this: [How to distribute your AngularJS module](https://medium.com/@kentcdodds/how-to-distribute-your-angularjs-module-e04d4dd58ddc)